### PR TITLE
Aggiungi gestione voucher regalo

### DIFF
--- a/admin/class-wcefp-vouchers-admin.php
+++ b/admin/class-wcefp-vouchers-admin.php
@@ -1,0 +1,62 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class WCEFP_Vouchers_Admin {
+
+    public static function init() {
+        add_action('admin_menu', [__CLASS__, 'register_menu']);
+    }
+
+    public static function register_menu() {
+        add_submenu_page(
+            'wcefp',
+            __('Voucher Regalo','wceventsfp'),
+            __('Voucher Regalo','wceventsfp'),
+            'manage_woocommerce',
+            'wcefp-vouchers',
+            [__CLASS__, 'dispatch']
+        );
+    }
+
+    public static function dispatch() {
+        if (!current_user_can('manage_woocommerce')) return;
+        $action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : '';
+        if ($action === 'view' && !empty($_GET['id'])) {
+            self::render_detail((int)$_GET['id']);
+        } else {
+            self::render_list();
+        }
+    }
+
+    private static function render_list() {
+        $table = new WCEFP_Vouchers_Table();
+        $table->process_bulk_action();
+        $table->prepare_items();
+        include WCEFP_PLUGIN_DIR . 'admin/views/vouchers-list.php';
+    }
+
+    private static function render_detail($id) {
+        global $wpdb;
+        $tbl = $wpdb->prefix . 'wcefp_vouchers';
+
+        $voucher = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$tbl} WHERE id=%d", $id), ARRAY_A);
+        if (!$voucher) {
+            echo '<div class="wrap"><h1>' . esc_html__('Voucher non trovato', 'wceventsfp') . '</h1></div>';
+            return;
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['wcefp_mark_used'])) {
+            check_admin_referer('wcefp_mark_used');
+            if (current_user_can('manage_woocommerce')) {
+                $wpdb->update($tbl, ['status' => 'used', 'redeemed_at' => current_time('mysql')], ['id' => $id], ['%s','%s'], ['%d']);
+                $voucher['status'] = 'used';
+                $voucher['redeemed_at'] = current_time('mysql');
+                echo '<div class="notice notice-success"><p>' . esc_html__('Voucher aggiornato.', 'wceventsfp') . '</p></div>';
+            }
+        }
+
+        $voucher['value'] = WCEFP_Vouchers_Table::get_voucher_value($voucher);
+
+        include WCEFP_PLUGIN_DIR . 'admin/views/voucher-detail.php';
+    }
+}

--- a/admin/class-wcefp-vouchers-table.php
+++ b/admin/class-wcefp-vouchers-table.php
@@ -1,0 +1,145 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!class_exists('WP_List_Table')) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class WCEFP_Vouchers_Table extends WP_List_Table {
+
+    public function __construct() {
+        parent::__construct([
+            'singular' => 'voucher',
+            'plural'   => 'vouchers',
+            'ajax'     => false,
+        ]);
+    }
+
+    public static function get_vouchers($per_page = 20, $page_number = 1) {
+        global $wpdb;
+        $tbl = $wpdb->prefix . 'wcefp_vouchers';
+
+        $orderby = !empty($_REQUEST['orderby']) ? sanitize_sql_orderby($_REQUEST['orderby']) : 'created_at';
+        $order   = (isset($_REQUEST['order']) && strtolower($_REQUEST['order']) === 'asc') ? 'ASC' : 'DESC';
+
+        $sql = "SELECT * FROM {$tbl} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+        return $wpdb->get_results($wpdb->prepare($sql, $per_page, ($page_number - 1) * $per_page), ARRAY_A);
+    }
+
+    public static function record_count() {
+        global $wpdb;
+        $tbl = $wpdb->prefix . 'wcefp_vouchers';
+        return (int) $wpdb->get_var("SELECT COUNT(*) FROM {$tbl}");
+    }
+
+    public function no_items() {
+        _e('Nessun voucher trovato.', 'wceventsfp');
+    }
+
+    public function get_columns() {
+        return [
+            'cb'         => '<input type="checkbox" />',
+            'id'         => __('ID', 'wceventsfp'),
+            'code'       => __('Codice', 'wceventsfp'),
+            'customer'   => __('Cliente', 'wceventsfp'),
+            'email'      => __('Email', 'wceventsfp'),
+            'created_at' => __('Data creazione', 'wceventsfp'),
+            'status'     => __('Stato', 'wceventsfp'),
+            'value'      => __('Valore (€)', 'wceventsfp'),
+            'actions'    => __('Azioni', 'wceventsfp'),
+        ];
+    }
+
+    protected function get_sortable_columns() {
+        return [
+            'id'         => ['id', false],
+            'code'       => ['code', false],
+            'created_at' => ['created_at', true],
+            'status'     => ['status', false],
+        ];
+    }
+
+    protected function column_cb($item) {
+        return sprintf('<input type="checkbox" name="voucher_ids[]" value="%d" />', $item['id']);
+    }
+
+    public function column_default($item, $column_name) {
+        switch ($column_name) {
+            case 'id':
+                return (int) $item['id'];
+            case 'code':
+                return esc_html($item['code']);
+            case 'customer':
+                return esc_html($item['recipient_name']);
+            case 'email':
+                return esc_html($item['recipient_email']);
+            case 'created_at':
+                return esc_html(mysql2date(get_option('date_format') . ' ' . get_option('time_format'), $item['created_at']));
+            case 'status':
+                return ($item['status'] === 'used') ? __('Usato', 'wceventsfp') : __('Non usato', 'wceventsfp');
+            case 'value':
+                $val = self::get_voucher_value($item);
+                return '€ ' . number_format((float)$val, 2, ',', '.');
+            case 'actions':
+                $url = add_query_arg([
+                    'page'   => 'wcefp-vouchers',
+                    'action' => 'view',
+                    'id'     => $item['id'],
+                ], admin_url('admin.php'));
+                return '<a href="' . esc_url($url) . '">' . __('Visualizza', 'wceventsfp') . '</a>';
+            default:
+                return '';
+        }
+    }
+
+    public function get_bulk_actions() {
+        return [
+            'mark_used'   => __('Segna come usati', 'wceventsfp'),
+            'mark_unused' => __('Annulla', 'wceventsfp'),
+        ];
+    }
+
+    public function process_bulk_action() {
+        if (empty($_POST['voucher_ids']) || !is_array($_POST['voucher_ids'])) {
+            return;
+        }
+        check_admin_referer('bulk-vouchers');
+        if (!current_user_can('manage_woocommerce')) return;
+
+        global $wpdb;
+        $tbl = $wpdb->prefix . 'wcefp_vouchers';
+        $ids = array_map('intval', $_POST['voucher_ids']);
+        $ids_sql = implode(',', $ids);
+        if ($this->current_action() === 'mark_used') {
+            $wpdb->query("UPDATE {$tbl} SET status='used', redeemed_at=NOW() WHERE id IN ({$ids_sql})");
+        } elseif ($this->current_action() === 'mark_unused') {
+            $wpdb->query("UPDATE {$tbl} SET status='unused', redeemed_at=NULL WHERE id IN ({$ids_sql})");
+        }
+    }
+
+    public function prepare_items() {
+        $per_page = 20;
+        $current_page = $this->get_pagenum();
+        $total_items = self::record_count();
+
+        $this->set_pagination_args([
+            'total_items' => $total_items,
+            'per_page'    => $per_page,
+        ]);
+
+        $this->items = self::get_vouchers($per_page, $current_page);
+    }
+
+    public static function get_voucher_value($item) {
+        $order = wc_get_order($item['order_id']);
+        if (!$order) return 0;
+        foreach ($order->get_items() as $it) {
+            if ((int)$it->get_product_id() === (int)$item['product_id']) {
+                $qty = max(1, (int)$it->get_quantity());
+                $total = (float)$it->get_total();
+                return $qty ? $total / $qty : 0;
+            }
+        }
+        return 0;
+    }
+}

--- a/admin/views/voucher-detail.php
+++ b/admin/views/voucher-detail.php
@@ -1,0 +1,33 @@
+<?php if (!defined('ABSPATH')) exit; ?>
+<div class="wrap">
+    <h1><?php _e('Dettaglio Voucher','wceventsfp'); ?></h1>
+    <table class="form-table">
+        <tr>
+            <th><?php _e('Codice','wceventsfp'); ?></th>
+            <td><?php echo esc_html($voucher['code']); ?></td>
+        </tr>
+        <tr>
+            <th><?php _e('Data','wceventsfp'); ?></th>
+            <td><?php echo esc_html(mysql2date(get_option('date_format').' '.get_option('time_format'), $voucher['created_at'])); ?></td>
+        </tr>
+        <tr>
+            <th><?php _e('Valore','wceventsfp'); ?></th>
+            <td>€ <?php echo number_format((float)$voucher['value'],2,',','.'); ?></td>
+        </tr>
+        <tr>
+            <th><?php _e('Stato','wceventsfp'); ?></th>
+            <td><?php echo ($voucher['status']=='used')?__('Usato','wceventsfp'):__('Non usato','wceventsfp'); ?></td>
+        </tr>
+        <tr>
+            <th><?php _e('Ordine','wceventsfp'); ?></th>
+            <td><?php $link = admin_url('post.php?post='.$voucher['order_id'].'&action=edit'); echo '<a href="'.esc_url($link).'">#'.esc_html($voucher['order_id']).'</a>'; ?></td>
+        </tr>
+    </table>
+    <?php if ($voucher['status'] !== 'used'): ?>
+    <form method="post" style="margin-top:20px;">
+        <?php wp_nonce_field('wcefp_mark_used'); ?>
+        <input type="hidden" name="wcefp_mark_used" value="1" />
+        <button type="submit" class="button button-primary"><?php _e('Segna come usato','wceventsfp'); ?></button>
+    </form>
+    <?php endif; ?>
+</div>

--- a/admin/views/vouchers-list.php
+++ b/admin/views/vouchers-list.php
@@ -1,0 +1,8 @@
+<?php if (!defined('ABSPATH')) exit; ?>
+<div class="wrap">
+    <h1><?php _e('Voucher Regalo','wceventsfp'); ?></h1>
+    <form method="post">
+        <?php wp_nonce_field('bulk-vouchers'); ?>
+        <?php $table->display(); ?>
+    </form>
+</div>

--- a/wceventsfp.php
+++ b/wceventsfp.php
@@ -113,7 +113,10 @@ add_action('plugins_loaded', function () {
     // Include admin (nuova classe)
     require_once WCEFP_PLUGIN_DIR . 'admin/class-wcefp-admin.php';
     require_once WCEFP_PLUGIN_DIR . 'admin/class-wcefp-meetingpoints.php';
+    require_once WCEFP_PLUGIN_DIR . 'admin/class-wcefp-vouchers-table.php';
+    require_once WCEFP_PLUGIN_DIR . 'admin/class-wcefp-vouchers-admin.php';
     WCEFP_Admin::init();
+    WCEFP_Vouchers_Admin::init();
 
     WCEFP()->init();
 });


### PR DESCRIPTION
## Summary
- Add voucher management admin pages under Eventi & Degustazioni menu
- Implement WP_List_Table for voucher list with bulk actions and detail view
- Load voucher admin classes during plugin initialization

## Testing
- `php -l admin/class-wcefp-vouchers-table.php`
- `php -l admin/class-wcefp-vouchers-admin.php`
- `php -l admin/views/vouchers-list.php`
- `php -l admin/views/voucher-detail.php`
- `php -l wceventsfp.php`


------
https://chatgpt.com/codex/tasks/task_e_68a61e534578832f954f695bf05f495f